### PR TITLE
更改在holotools中的開啟方式，待使用者開啟後再分配空間，並重新排列iframe；加入icon在控制列。

### DIFF
--- a/src/SupportWebsite/holotools/InitHT.js
+++ b/src/SupportWebsite/holotools/InitHT.js
@@ -27,13 +27,25 @@ export function InitHT(messageposter) {
   })();
   function TryInsChat() {
     const parent = $(`.container-watch`);
+    const theme = $('html:eq(0)').hasClass("md-theme-hololight") ? "hololight" : "holodark";
     if (reportmode) console.log("parent", parent);
     if (parent.length > 0 && iswatch) {
+      const iconParent = $('.live-control-button:eq(0)');
+      const icon = $('<i data-v-2989253e="" class="md-icon md-icon-font md-theme-' + theme + '" data-toggle="collapse" data-target="#PTTMain">local_parking</i>');
+      iconParent.append(icon);
       const pluginwidth = GM_getValue('PluginWidth', 400);
+      const pluginwidth0 = "0";
+      let now = pluginwidth0;
+      iconParent.on('click', function () {
+        now = (now === pluginwidth0 ? pluginwidth : pluginwidth0);
+        $('#pttchatparent').css("flex", "0 0 " + now + "px");
+        const defaultTypesettingBtn = $(`.md-icon.md-icon-font:eq(${$('.md-icon.md-icon-font').length - 6})`);
+        defaultTypesettingBtn.trigger("click");
+      })
       const fakeparent = $(`<div id="fakeparent" class="d-flex flex-row"></div>`);
       const defaultVideoHandler = $(`<div id="holotoolsvideohandler" style="flex:1 1 auto;"></div>`);
       const defaultVideo = $(`.player-container.hasControls`);
-      const PTTChatHandler = $(`<div id="pttchatparent" class="p-0 d-flex" style="flex:0 0 ` + pluginwidth + `px;position:relative;"></div>`);
+      const PTTChatHandler = $(`<div id="pttchatparent" class="p-0 d-flex" style="flex:0 0 0px;position:relative;"></div>`);
       parent.append(fakeparent);
       fakeparent.append(defaultVideoHandler);
       defaultVideoHandler.append(defaultVideo);


### PR DESCRIPTION
預覽：

![HoloTools - Google Chrome 2021-04-25 07-32-57_Trim (online-video-cutter com)](https://user-images.githubusercontent.com/70936803/115975897-5f297b00-a59b-11eb-84e5-b058f39ec8d4.gif)

已知問題：開關速度太快會來不及讓collapse動畫完成，縮起來時navbar會稍微露出但不影響影片播放區域，故留下原本的按鈕供操作。