### PR TITLE
修復新的開啟方式在舊版holotools中的錯誤，暫時移除新版holotools中的此功能。

### DIFF
--- a/src/SupportWebsite/holotools/InitHT.js
+++ b/src/SupportWebsite/holotools/InitHT.js
@@ -30,22 +30,36 @@ export function InitHT(messageposter) {
     const theme = $('html:eq(0)').hasClass("md-theme-hololight") ? "hololight" : "holodark";
     if (reportmode) console.log("parent", parent);
     if (parent.length > 0 && iswatch) {
-      const iconParent = $('.live-control-button:eq(0)');
-      const icon = $('<i data-v-2989253e="" class="md-icon md-icon-font md-theme-' + theme + '" data-toggle="collapse" data-target="#PTTMain">local_parking</i>');
-      iconParent.append(icon);
       const pluginwidth = GM_getValue('PluginWidth', 400);
       const pluginwidth0 = "0";
-      let now = pluginwidth0;
-      iconParent.on('click', function () {
-        now = (now === pluginwidth0 ? pluginwidth : pluginwidth0);
-        $('#pttchatparent').css("flex", "0 0 " + now + "px");
-        const defaultTypesettingBtn = $(`.md-icon.md-icon-font:eq(${$('.md-icon.md-icon-font').length - 6})`);
-        defaultTypesettingBtn.trigger("click");
-      })
+      if (/https:\/\/hololive\.jetri\.co\/#\/watch/.exec(iswatch)) {
+        const liveControls = $('.live-controls');
+        liveControls.css("width", "auto");
+        const datahash = Object.keys(liveControls.data())[0];
+        const iconParent = $(`<div data-${datahash} class="live-control live-control-quad bg-300" type="button"></div>`);
+        const icon = $(`<i data-${datahash} class="md-icon md-icon-font md-theme-${theme}" title="PTT">local_parking</i>`);
+        iconParent.append(icon);
+        liveControls.prepend(iconParent);
+        let now = pluginwidth0;
+        let collapseStart = false;
+        let collapseEnd = true;
+        iconParent.on('click', function () {
+          if (collapseEnd || !collapseStart) {
+            if (now === "0") $("#PTTMain").collapse("show");
+            else $("#PTTMain").collapse("hide");
+            now = (now === pluginwidth0 ? pluginwidth : pluginwidth0);
+            $('#pttchatparent').css("flex", "0 0 " + now + "px");
+            const defaultTypesettingBtn = $(`.md-icon.md-icon-font:eq(${$('.md-icon.md-icon-font').length - 6})`);
+            defaultTypesettingBtn.trigger("click");
+          }
+        });
+        $(document).on("show.bs.collapse hide.bs.collapse", "#PTTMain", function () { collapseStart = true; collapseEnd = false; });
+        $(document).on("shown.bs.collapse hidden.bs.collapse", "#PTTMain", function () { collapseStart = false; collapseEnd = true; });
+      }
       const fakeparent = $(`<div id="fakeparent" class="d-flex flex-row"></div>`);
       const defaultVideoHandler = $(`<div id="holotoolsvideohandler" style="flex:1 1 auto;"></div>`);
       const defaultVideo = $(`.player-container.hasControls`);
-      const PTTChatHandler = $(`<div id="pttchatparent" class="p-0 d-flex" style="flex:0 0 0px;position:relative;"></div>`);
+      const PTTChatHandler = $(`<div id="pttchatparent" class="p-0 d-flex" style="flex:0 0 ` + pluginwidth + `px;position:relative;"></div>`);
       parent.append(fakeparent);
       fakeparent.append(defaultVideoHandler);
       defaultVideoHandler.append(defaultVideo);


### PR DESCRIPTION
修復#44 ，並將原本插入到暫停按鈕上方的PTT按鈕獨立出來。
![image](https://user-images.githubusercontent.com/70936803/117004173-5d3c8600-ad18-11eb-8846-1c2a0bddd461.png)

使用模式回復到跟先前一樣，載入後會顯示分割後的畫面，由使用者決定是否關閉PTT聊天室顯示。
因為新版holotools在重新調整布局之後有機率會重新整理，故先移除此功能。