### PR TITLE
改用observer簡化程式。

### DIFF
--- a/src/SupportWebsite/holodex/InitHD.js
+++ b/src/SupportWebsite/holodex/InitHD.js
@@ -62,6 +62,7 @@ export function InitHD (messageposter) {
         if (GM_getValue('PluginTypeHolodex', '1') === '0') {
           clearInterval(mainTimer)
           if (observer) observer.disconnect()
+          $('[name="ptt-boot-btn"]').remove()
           iconPTT.css('display', 'block')
           GM_setValue('PluginTypeHolodex', '1')
         } else {
@@ -110,20 +111,16 @@ export function InitHD (messageposter) {
     const btnParentSet = $('.centered-btn')
     btnParentSet.each(index => {
       const btnParent = btnParentSet.eq(index)
-      if (btnParent.find($('[name="ptt-boot-btn"]')).length === 0) {
-        if (!btnParent.children().eq(0).hasClass('d-flex')) {
-          btnParent.prepend($('<div class="d-flex"></div>').prepend(btnParent.children()))
-          btnParent.css('flex-direction', 'column')
-        }
-        const btn = btnParent.children().eq(0).children().eq(1).clone().attr({ name: 'ptt-boot-btn', style: 'background-color:rgb(130, 30, 150)!important;margin-top:10px;width:165px;' }).appendTo(btnParent)
-        btn.find('path').attr('d', 'M13 3H6v18h4v-6h3c3.31 0 6-2.69 6-6s-2.69-6-6-6zm.2 8H10V7h3.2c1.1 0 2 .9 2 2s-.9 2-2 2z')
-        btn.on('click', () => {
-          const gridIndex = btn.parents().eq(3).index()
-          btnParent.children().eq(0).children().eq(1).trigger('click')
-          appendPtt2Cell(gridIndex)
-          if (reportmode) console.log(`grid-#${gridIndex}-boot-button clicked`)
-        })
-      }
+      if (btnParent.find($('[name="ptt-boot-btn"]')).length !== 0) return
+      const btn = btnParent.children().eq(0).clone()
+      btn.attr({ name: 'ptt-boot-btn', style: 'background-color:rgb(130, 30, 150)!important;margin-top:8px;width:190px;' }).appendTo(btnParent)
+      btn.find($('.v-btn__content')).eq(0).text('P').css('font-size', '20px')
+      btn.on('click', () => {
+        const gridIndex = btn.parents().eq(3).index()
+        btnParent.children().eq(1).children().eq(1).trigger('click')
+        appendPtt2Cell(gridIndex)
+        if (reportmode) console.log(`grid-#${gridIndex}-boot-button clicked`)
+      })
     })
   }
 

--- a/src/SupportWebsite/holodex/InitHD.js
+++ b/src/SupportWebsite/holodex/InitHD.js
@@ -7,18 +7,9 @@ export function InitHD (messageposter) {
   const WhiteTheme = ThemeCheck('html', '250, 250, 250')
 
   let recentWatch = false
-  let resizeTimer
-  let resizeObserver
-  let overrideBtn
-
-  // watch if window size changed
-  $(window).on('resize', () => {
-    if (resizeTimer) clearTimeout(resizeTimer)
-    resizeTimer = setTimeout(() => {
-      checkOriginMenuBtn()
-      if (reportmode) console.log('window size change')
-    }, 500)
-  })
+  let repositionTimer
+  let observer
+  let layoutObserver
 
   setInterval(() => {
     const url = /https:\/\/holodex\.net\/multiview/.exec(window.location.href)
@@ -36,7 +27,7 @@ export function InitHD (messageposter) {
     const parent = defaultVideo.parent()
     const holodexStyle = $('body').children().eq(1).hasClass('theme--light') ? '#757575' : '#F2F2F2'
     const iconSwitch = $(`<button type="button" id="ptt-switch-btn" title="切換PTT顯示模式" style="width: 36px; margin: 4px; padding-top: 6px"><svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="${holodexStyle}"><path d="M0 0h24v24H0z" fill="none"/><path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z"/></svg></button>`)
-    const iconPTT = $('<button type="button" id="ptt-collapse-btn" title="展開/隱藏PTT聊天室" style="height: 36px; width: 36px; margin: 4px; font-size: 21px;">P</button>')
+    const iconPTT = $('<button type="button" id="ptt-collapse-btn" title="展開/隱藏PTT聊天室" style="height: 36px; width: 36px; margin: 3px; font-size: 21px;">P</button>')
     liveControls.prepend(iconPTT, iconSwitch)
     parent.append(fakeparent)
     fakeparent.append(defaultVideoHandler)
@@ -49,7 +40,6 @@ export function InitHD (messageposter) {
     let collapseStart = false
     let collapseEnd = true
     iconPTT.on('click', () => {
-      if ($('#pttchatparent #PTTChat').length === 0) $('#PTTChat').css('display', 'block').appendTo($('#pttchatparent'))
       if (GM_getValue('PluginTypeHolodex', '1') === '1') {
         if (collapseEnd || !collapseStart) {
           if (nowWidth === 0) {
@@ -71,108 +61,49 @@ export function InitHD (messageposter) {
       if (confirm(`切換為${GM_getValue('PluginTypeHolodex', '1') === '0' ? '舊' : '新'}版PTT顯示模式？`)) {
         if (GM_getValue('PluginTypeHolodex', '1') === '0') {
           clearInterval(mainTimer)
-
+          if (observer) observer.disconnect()
           iconPTT.css('display', 'block')
-          $('#PTTChat-contents').css('height', `${GM_getValue('PluginHeight', 400)}`)
-          $('#PTTChat-app').css('height', '')
-
-          if ($('#PTTChat').length !== 0) initPttChatPosition()
-          $('[name="ptt-boot-btn"]').remove()
           GM_setValue('PluginTypeHolodex', '1')
         } else {
           iconPTT.css('display', 'none')
           $('#pttchatparent').css('flex', '0 0 0px')
-          initPttChatPosition()
           GM_setValue('PluginTypeHolodex', '0')
-          mainTimer = embedProcedure()
+          mainTimer = setInterval(appendPttEmbedBtn, 1000)
         }
+        initPttChatStyle()
+        if (reportmode) console.log('display mode changed')
       }
-      if (reportmode) console.log('display mode changed')
     })
 
-    function embedProcedure () {
-      const t = setInterval(() => {
-        appendPttEmbedBtn()
-        checkAutoRemove()
-        if (!overrideBtn || overrideBtn.length === 0) checkOverrideSettingBtn()
-      }, 1000)
-      return t
-    }
-
-    let mainTimer = GM_getValue('PluginTypeHolodex', '1') === '0'
-      ? embedProcedure()
-      : undefined
-
-    recentWatch = true
-    initPttChatPosition()
-    checkOriginMenuBtn()
-    if (reportmode) console.log('main initialize done')
-  }
-
-  function checkOriginMenuBtn () {
-    function replaceOriginalMenuBtn (id, svg, title, coverSvg = undefined) {
-      const btnSvg = $(`.v-toolbar__content path[d="${svg}"]`)
-      if (btnSvg.length === 1) {
-        const originalBtn = btnSvg.parents().eq(3)
-        if ($(`#fake-menu-${id}-btn`).length === 0) {
-          const fakeBtn = originalBtn.clone().attr({ id: `fake-menu-${id}-btn`, title: title })
-          fakeBtn.insertAfter(originalBtn)
-          originalBtn.css('display', 'none')
-          fakeBtn.off('click').on('click', () => {
-            if ($('#pttchatparent #PTTChat').length === 0) initPttChatPosition()
-            originalBtn.trigger('click')
-            if (reportmode) console.log(title)
-          })
-        } else {
-          if (reportmode) console.warn('couldn\'t detect original btn.')
-          if (coverSvg) $(`.v-toolbar__content path[d="${coverSvg}"]`).parents().eq(3).css('display', 'block')
-          $(`#fake-menu-${id}-btn`).css('display', 'none')
-        }
-      } else if (btnSvg.length === 2) {
-        const fakeBtn = $(`#fake-menu-${id}-btn`)
-        fakeBtn.css('display', 'block')
-        const originalBtn = btnSvg.parent().parent().parent().parent().not(fakeBtn)
-        originalBtn.css('display', 'none')
-
-        if (!coverSvg) {
-          fakeBtn.off('click').on('click', () => {
-            if ($('#pttchatparent #PTTChat').length === 0) initPttChatPosition()
-            originalBtn.trigger('click')
-            if (reportmode) console.log(title)
-          })
-        }
+    function initPttChatStyle () {
+      switch (GM_getValue('PluginTypeHolodex', '1')) {
+        case '0':
+          if ($('.vue-grid-layout #PTTChat').length === 0) $('#PTTChat').appendTo($('.vue-grid-layout')).css('display', 'none')
+          break
+        case '1':
+          if ($('#pttchatparent #PTTChat').length === 0) $('#PTTChat').appendTo($('#pttchatparent'))
+          $('#PTTChat-contents').css('height', `${GM_getValue('PluginHeight', 400)}`)
+          $('#PTTChat-app').height('')
+          $('#PTTChat').addClass('w-100').attr('style', '')
+          break
       }
+      $('#PTTMain').collapse('hide')
     }
 
-    replaceOriginalMenuBtn(
-      'delete',
-      'M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z',
-      '清除播放清單',
-      'M7 3H5V9H7V3M19 3H17V13H19V3M3 13H5V21H7V13H9V11H3V13M15 7H13V3H11V7H9V9H15V7M11 21H13V11H11V21M15 15V17H17V21H19V17H21V15H15Z'
-    )
-    replaceOriginalMenuBtn(
-      'defaultLayout',
-      'M4,2H20A2,2 0 0,1 22,4V20A2,2 0 0,1 20,22H4C2.92,22 2,21.1 2,20V4A2,2 0 0,1 4,2M4,4V11H11V4H4M4,20H11V13H4V20M20,20V13H13V20H20M20,4H13V11H20V4Z',
-      '預設佈局'
-    )
-  }
-
-  function initPttChatPosition () {
     if ($('#PTTChat').length === 0) {
       InitApp($('#pttchatparent'), WhiteTheme, true, messageposter, true)
       ChangeLog()
-      const pttFrame = $('<div id="ptt-frame-parent" style="position: absolute;"><iframe id="PTTframe" src="//term.ptt.cc/?url=https://holodex.net" style="display:none;">你的瀏覽器不支援iframe</iframe></div>')
+      const pttFrame = $('<div id="ptt-frame-parent" style="position: absolute; z-index: 6;"><iframe id="PTTframe" src="//term.ptt.cc/?url=https://holodex.net" style="display:none;">你的瀏覽器不支援iframe</iframe></div>')
       $('.vue-grid-layout').append(pttFrame)
       listenPttFrameBtn()
       if (reportmode) console.log('create PTTChat instance in holodex')
-    } else {
-      $('#PTTChat').appendTo($('#fakeparent')).css('display', 'none')
-      $('#PTTMain').collapse('hide')
-      const chatParent = $('[name="pttchat-parent"]')
-      if (chatParent.length !== 0) chatParent.remove()
-      if (resizeObserver) resizeObserver.disconnect()
-      if (reportmode) console.log('PTTChat reposition')
     }
+
+    let mainTimer = GM_getValue('PluginTypeHolodex', '1') === '0'
+      ? setInterval(appendPttEmbedBtn, 1000)
+      : undefined
+    recentWatch = true
+    if (reportmode) console.log('main initialize done')
   }
 
   function appendPttEmbedBtn () {
@@ -189,7 +120,6 @@ export function InitHD (messageposter) {
         btn.on('click', () => {
           const gridIndex = btn.parents().eq(3).index()
           btnParent.children().eq(0).children().eq(1).trigger('click')
-          initPttChatPosition()
           appendPtt2Cell(gridIndex)
           if (reportmode) console.log(`grid-#${gridIndex}-boot-button clicked`)
         })
@@ -197,54 +127,78 @@ export function InitHD (messageposter) {
     })
   }
 
-  function checkAutoRemove () {
-    const gridItems = $('.vue-grid-item')
-    gridItems.each(index => {
-      const item = gridItems.eq(index)
-      if (item.find($('.mv-frame.ma-auto')).length === 0) return
-      if (item.find($('[name="fake-grid-item-delete-btn"]')).length !== 0) return
-      const originBtn = item.find($('path[d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"]')).parents().eq(3)
-      if (originBtn.length !== 0) {
-        const fakeDeleteBtn = originBtn.clone().attr('name', 'fake-grid-item-delete-btn')
-        fakeDeleteBtn.insertAfter(originBtn)
-        originBtn.css('display', 'none')
-        fakeDeleteBtn.off('click').on('click', () => {
-          if ($('#pttchatparent #PTTChat').length === 0) initPttChatPosition()
-          originBtn.trigger('click')
-          if (reportmode) console.log('auto remove')
-        })
-      }
+  function appendPtt2Cell (gridIndex) {
+    if ($('.vue-grid-layout #PTTChat').length === 0) $('#PTTChat').appendTo($('.vue-grid-layout')).css('display', 'none')
+    const cell = $('.vue-grid-item').eq(gridIndex)
+    const config = { attributes: true }
+    if (observer) observer.disconnect()
+    observer = new MutationObserver(() => {
+      if (repositionTimer) clearTimeout(repositionTimer)
+      repositionTimer = setTimeout(repositionPttChat, 10, cell)
     })
+    observer.observe(cell[0], config)
+    checkFilledWithVideo(cell)
   }
 
-  function appendPtt2Cell (gridIndex) {
-    const gridParent = $('.vue-grid-layout').children().eq(gridIndex)
-    const cellContent = gridParent.find($('.cell-content')).not('.pt-4')
-    const cellControl = gridParent.find($('.cell-content .d-flex'))
-    if (cellContent.length === 0) setTimeout(appendPtt2Cell, 250, gridIndex)
+  /** @param {JQuery} parentCell */
+  function repositionPttChat (parentCell) {
+    const sheet = parentCell.find($('.mv-cell.v-sheet')).eq(0)
+    const editMode = sheet.hasClass('edit-mode')
+    const height = sheet.height()
+    const width = sheet.width()
+
+    let el = sheet[0]
+    let x = 0
+    let y = 0
+    while (el.className !== 'vue-grid-layout') {
+      x += el.offsetLeft - el.scrollLeft + el.clientLeft
+      y += el.offsetTop - el.scrollLeft + el.clientTop
+      el = el.offsetParent
+    }
+
+    $('#PTTChat-contents').height('')
+    if (editMode) {
+      $('#PTTChat').attr('style', `z-index: 5; margin: ${y + 20}px 0px 0px ${x + 20}px; width: ${width}px !important;`)
+      $('#PTTChat-app').height(height - 68)
+    } else {
+      $('#PTTChat').attr('style', `z-index: 5; margin: ${y}px 0px 0px ${x}px; width: ${width}px !important;`)
+      $('#PTTChat-app').height(height - 24)
+    }
+    $('#PTTChat').removeClass('w-100').css('display', 'block')
+    $('#PTTMain').collapse('show')
+    checkCellRemoved(parentCell[0])
+  }
+
+  function checkCellRemoved (observeredNode) {
+    if ($('.vue-grid-layout').length === 0) setTimeout(checkCellRemoved, 10, observeredNode)
     else {
-      cellContent.css('position', 'relative').prepend($('<div name="pttchat-parent" style="height: calc(100% - 25px);width: 100%;position: absolute;z-index: 6;"></div>'))
-      const pttChatParent = $('#PTTChat').parent('[name="pttchat-parent"]')
-      $('#PTTChat').appendTo(cellContent.children().eq(0)).css('display', 'block')
-      if (pttChatParent.length !== 0) pttChatParent.remove()
-
-      const chatBtn = cellControl.find($('path[d="M20,2H4C2.9,2,2,2.9,2,4v18l4-4h14c1.1,0,2-0.9,2-2V4C22,2.9,21.1,2,20,2zM9.9,10.8v3.8h-2v-3.8L5.1,6.6h2.4l1.4,2.2 l1.4-2.2h2.4L9.9,10.8zM18.9,8.6h-2v6h-2v-6h-2v-2h6V8.6z"]')).parents().eq(3)
-      if (chatBtn.css('background-color') === 'rgb(240, 98, 146)') {
-        chatBtn.trigger('click')
-      }
-
-      $('#PTTChat-contents').css('height', '')
-      $('#PTTMainBtn').off('click').on('click', () => $('[name="pttchat-parent"]').css('z-index', $('[name="pttchat-parent"]').css('z-index') === 'auto' ? '6' : 'auto'))
-
-      if (resizeObserver) resizeObserver.disconnect()
-      resizeObserver = new ResizeObserver(entries => {
-        $('#PTTChat-app').css('height', entries[0].contentRect.height)
+      if (layoutObserver) layoutObserver.disconnect()
+      layoutObserver = new MutationObserver(mutations => {
+        mutations.forEach(el => {
+          el.removedNodes.forEach(e => {
+            if (e === observeredNode) hidePttChatInGrid()
+          })
+        })
       })
-      resizeObserver.observe(document.getElementById('PTTChat').parentNode)
+      const config = { childList: true }
+      layoutObserver.observe($('.vue-grid-layout')[0], config)
+    }
+  }
 
-      listenEditBtn(gridParent)
-      checkFilledVideo(gridParent)
-      $('#PTTMain').collapse('show')
+  function hidePttChatInGrid () {
+    if ($('.vue-grid-layout #PTTChat').length !== 0) {
+      $('#PTTChat').css('display', 'none')
+      $('#PTTMain').collapse('hide')
+    }
+    if (observer) observer.disconnect()
+    if (reportmode) console.log('hide PTTChat')
+  }
+
+  function checkFilledWithVideo (cell) {
+    if (cell.find($('.mv-frame.ma-auto')).length === 0) setTimeout(checkFilledWithVideo, 1000, cell)
+    else {
+      if (reportmode) console.log('cell fill with video, remove PTTChat')
+      hidePttChatInGrid()
     }
   }
 
@@ -257,89 +211,25 @@ export function InitHD (messageposter) {
         let el = $('#PTTMainBtn')[0]
         let x = 0
         let y = 0
-        while (el) {
+        while (el && el.className !== 'v-main__wrap') {
           x += el.offsetLeft - el.scrollLeft + el.clientLeft
           y += el.offsetTop - el.scrollLeft + el.clientTop
+          // console.log(el)
           el = el.offsetParent
         }
-        y -= 35
-        const height = $('#PTTChat-app').height() - 30
-        const width = $('#PTTChat-app').width()
-        $('#ptt-frame-parent').css('margin', `${y}px 0px 0px ${x}px`).css('z-index', 6)
-        $('#PTTframe').css({ display: 'block', height: `${height}px`, width: `${width}px` })
+        y = y + $('#PTTChat-navbar').height() - document.querySelector('.v-main__wrap .v-toolbar__content').offsetHeight
+        const height = $('#PTTChat-app').height() - $('#PTTChat-navbar').height()
+        const width = $('#PTTChat').width()
+        $('#ptt-frame-parent').css('margin', `${y}px 0px 0px ${x}px`)
+        $('#PTTframe').css({ height: `${height}px`, width: `${width}px` })
 
-        if ($('#PTTChat-contents-PTT').width() === 0) $('#PTTframe').css('border', 'none')
-        else $('#PTTframe').css('border', 'revert')
+        // 轉場動畫 50ms
+        if ($('#PTTChat-contents-PTT').width() === 0) $('#PTTframe').css({ border: 'none', display: 'none' })
+        else $('#PTTframe').css({ border: 'revert', display: 'block' })
 
-        if ($('#nav-item-PTT').hasClass('active')) setTimeout(repositionFrame, 100)
-        else {
-          $('#ptt-frame-parent').css('z-index', -1)
-          $('#PTTframe').css('display', 'none')
-        }
+        if ($('#nav-item-PTT').hasClass('active')) setTimeout(repositionFrame, 10)
+        else $('#PTTframe').css({ border: 'none', display: 'none' })
       }
-    })
-  }
-
-  function listenEditBtn (gridParent) {
-    const editBtn = gridParent.find($('path[d="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"]')).parents().eq(3)
-    if (editBtn.length === 0) setTimeout(listenEditBtn, 250, gridParent)
-    else {
-      editBtn.off('click').on('click', () => {
-        if (gridParent.find($('#PTTChat')).length !== 0) {
-          $('[name="pttchat-parent"]').css('height', 'calc(100% - 35px)')
-          listenCtrlBtn(gridParent)
-        }
-      })
-    }
-  }
-
-  function listenCtrlBtn (gridParent) {
-    const btnParent = gridParent.find($('.cell-control')).eq(0)
-    if (btnParent.length === 0) setTimeout(listenCtrlBtn, 250, gridParent)
-    else {
-      const originBackBtn = btnParent.children().eq(0)
-      const fakeBackBtn = originBackBtn.clone()
-      const originDeleteBtn = btnParent.children().eq(2)
-      const fakeDeleteBtn = originDeleteBtn.clone()
-      const confirmBtn = btnParent.children().eq(1)
-      originBackBtn.css('display', 'none')
-      originDeleteBtn.css('display', 'none')
-      fakeBackBtn.insertAfter(originBackBtn)
-      fakeDeleteBtn.insertAfter(originDeleteBtn)
-      confirmBtn.off('click').on('click', () => {
-        if (gridParent.find($('#PTTChat')).length !== 0) {
-          gridParent.find($('[name="pttchat-parent"]')).css({ height: 'calc(100% - 25px)', width: '100%' })
-          $('#PTTChat-app').css('height', $('#PTTChat').parent().css('height'))
-          listenEditBtn(gridParent)
-        }
-      })
-      fakeBackBtn.off('click').on('click', () => {
-        if (gridParent.find($('#PTTChat')) !== 0) initPttChatPosition()
-        originBackBtn.trigger('click')
-      })
-      fakeDeleteBtn.off('click').on('click', () => {
-        if (gridParent.find($('#PTTChat')).length !== 0) initPttChatPosition()
-        originDeleteBtn.trigger('click')
-      })
-    }
-  }
-
-  function checkFilledVideo (gridParent) {
-    if (gridParent.find($('.mv-frame.ma-auto')).length === 0) setTimeout(checkFilledVideo, 1000, gridParent)
-    else {
-      console.log(gridParent.find($('.mv-frame.ma-auto')).parent())
-    }
-  }
-
-  function checkOverrideSettingBtn () {
-    overrideBtn = $('[role="document"] span.v-btn__content').eq(0).parent()
-    if (overrideBtn.length === 0) return
-    const fakeOverrideBtn = overrideBtn.clone()
-    fakeOverrideBtn.insertAfter(overrideBtn)
-    overrideBtn.css('display', 'none')
-    fakeOverrideBtn.off('click').on('click', () => {
-      if ($('#pttchatparent #PTTChat').length === 0) initPttChatPosition()
-      overrideBtn.trigger('click')
     })
   }
 }


### PR DESCRIPTION
找到一個方便的物件所以修改了一下內容，讓聊天室像之前PTT的視窗直接覆蓋在現有畫面上，減少holodex改版後產生的問題。

如果MutationObserver不設閾值的話(目前10ms)會一直觸發更新位置，有機會讓瀏覽器卡住
目前在拖曳cell的時候在視覺上會有點卡，不過我認為還能接受

垃圾桶、返回、編輯等按鈕的監聽也一併移除了
考慮到實用性，按下橘黃色返回按鈕不會隱藏聊天室的問題我想就直接用聊天室左上角的P按鈕摺疊就好了，如果有必要我再加上去

目前是草稿，有問題的話會比較好修改，如果測試OK我再整理一下合併進來。